### PR TITLE
Role Authentication Middleware

### DIFF
--- a/api/middleware/roleAuthentication.js
+++ b/api/middleware/roleAuthentication.js
@@ -1,0 +1,21 @@
+const roleAuthentication = (...args) => (req, res, next) => {
+  // role type is inside req.profile.body
+  //const { type } = req.profile
+  const { type } = req.profile;
+  let userType;
+  if (type === 1) {
+    userType = 'instructor';
+  } else if (type === 2) {
+    userType = 'parent';
+  } else if (type === 3) {
+    userType = 'admin';
+  }
+  //check to see if role matcheds the role that have access to the endpoint
+  if ([...args].includes(userType)) {
+    next();
+  } else {
+    res.status(404).json({ error: 'No Access' });
+  }
+};
+
+module.exports = roleAuthentication;

--- a/api/middleware/roleAuthentication.js
+++ b/api/middleware/roleAuthentication.js
@@ -1,6 +1,5 @@
 const roleAuthentication = (...args) => (req, res, next) => {
   // role type is inside req.profile.body
-  //const { type } = req.profile
   const { type } = req.profile;
   let userType;
   if (type === 1) {


### PR DESCRIPTION
Functionality: We set up a middleware that ensures the user's who hit the endpoints actually have the proper authorization to hit this endpoint. It's a simple middleware that receives the arguments of the user types that should be allowed access to the endpoint. 
For instance, an endpoint that should only have 'instructor' access, the middleware can be called in the router by writing "roleAuthentication('instructor')". 

https://www.loom.com/share/0499a0521158402bbafc51fb23b98f5f