### PR TITLE
Get method added that give parent ability to see all available sessions

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -31,6 +31,7 @@ const courseRouter = require('./course/courseRouter');
 const scheduleRouter = require('./schedules/scheduleRouter');
 const dsRouter = require('./dsService/dsRouter');
 const newsfeedRouter = require('./newsfeed/newsfeedRouter');
+const sessionRouter = require('./session/sessionRouter');
 
 const app = express();
 
@@ -69,6 +70,7 @@ app.use(['/schedule', '/schedules'], scheduleRouter);
 app.use(['/children', '/child'], childrenRouter);
 app.use(['/newsfeed', '/news'], newsfeedRouter);
 app.use('/data', dsRouter);
+app.use(['/session', '/sessions'], sessionRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/api/session/sessionModel.js
+++ b/api/session/sessionModel.js
@@ -1,0 +1,33 @@
+const db = require('../../data/db-config');
+
+const getSessions = async () => {
+  const joinedTabkes = await db('sessions as se')
+    .join('schedules as sc', 'se.schedule_id', '=', 'sc.id')
+    .join('courses as co', 'co.id', '=', 'sc.course_id')
+    .join('instructors as ins', 'sc.instructor_id', '=', 'ins.id')
+    .join('profiles as p', 'p.okta', '=', 'ins.user_id');
+  const res = [];
+  joinedTabkes.forEach((item) => {
+    res.push({
+      session_id: item.id,
+      course_id: item.course_id,
+      instructor_id: item.instructor_id,
+      instructor_name: item.name,
+      instructor_rating: item.rating,
+      size: item.size,
+      subject: item.subject,
+      description: item.description,
+      prereqs: item.prereqs,
+      start_date: item.start_date,
+      end_date: item.end_date,
+      start_time: item.start_time,
+      end_time: item.end_time,
+      location: item.location,
+    });
+  });
+  return res;
+};
+
+module.exports = {
+  getSessions,
+};

--- a/api/session/sessionModel.js
+++ b/api/session/sessionModel.js
@@ -1,13 +1,13 @@
 const db = require('../../data/db-config');
 
 const getSessions = async () => {
-  const joinedTabkes = await db('sessions as se')
+  const fullSessionInformation = await db('sessions as se')
     .join('schedules as sc', 'se.schedule_id', '=', 'sc.id')
     .join('courses as co', 'co.id', '=', 'sc.course_id')
     .join('instructors as ins', 'sc.instructor_id', '=', 'ins.id')
     .join('profiles as p', 'p.okta', '=', 'ins.user_id');
   const res = [];
-  joinedTabkes.forEach((item) => {
+  fullSessionInformation.forEach((item) => {
     res.push({
       session_id: item.id,
       course_id: item.course_id,

--- a/api/session/sessionRouter.js
+++ b/api/session/sessionRouter.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const authRequired = require('../middleware/authRequired');
+const Session = require('./sessionModel');
+const router = express.Router();
+// eslint-disable-next-line
+router.get('/', authRequired, async function (req, res, next) {
+  try {
+    const allAvailableSessions = await Session.getSessions();
+    res.status(200).json(allAvailableSessions);
+  } catch (error) {
+    next({
+      status: 500,
+      message: 'something went wrong while getting sessions',
+    });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
As a parent, he/she can see available sessions in the calendar. 
a new router was created that joins multiple tables and, in an orderly fashion, send the requested data to the frontend
```
[
    {
        "session_id": 1,
        "course_id": 1,
        "instructor_id": 1,
        "instructor_name": "Test003",
        "instructor_rating": 2,
        "size": 15,
        "subject": "CS101",
        "description": "Computer Science fundamentals",
        "prereqs": null,
        "start_date": "2022-10-10T07:00:00.000Z",
        "end_date": "2022-10-10T07:00:00.000Z",
        "start_time": "17:00:00",
        "end_time": "18:00:00",
        "location": "https://zoom.us/my/john123"
    },
]

```
in the future, we will need to create/modify an endpoint that sends the instructor information to the FE so that the parent can see more information about their child's-teacher 

loom video: https://www.loom.com/share/7ee3666256fc44d69ac43f42980df65e 



