### PR TITLE
Bug/authRequired first before DB interaction

### DIFF
--- a/api/admin/adminRouter.js
+++ b/api/admin/adminRouter.js
@@ -14,7 +14,7 @@ router.get('/', authRequired, function (req, res) {
       res.status(500).json({ message: err.message });
     });
 });
-router.get('/:id', checkAdminExist, authRequired, function (req, res, next) {
+router.get('/:id', authRequired, checkAdminExist, function (req, res, next) {
   try {
     res.status(200).json(req.admin);
   } catch (error) {
@@ -31,7 +31,7 @@ router.post('/', checkPayload, authRequired, async (req, res, next) => {
   }
 });
 
-router.put('/:id', checkAdminExist, authRequired, async (req, res, next) => {
+router.put('/:id', authRequired, checkAdminExist, async (req, res, next) => {
   try {
     const id = req.params.id;
     const { profile_id } = req.admin;
@@ -45,7 +45,7 @@ router.put('/:id', checkAdminExist, authRequired, async (req, res, next) => {
   }
 });
 
-router.delete('/:id', checkAdminExist, authRequired, async (req, res, next) => {
+router.delete('/:id', authRequired, checkAdminExist, async (req, res, next) => {
   const id = req.params.id;
   try {
     const deletedAdmin = await Admins.removeAdmin(id);

--- a/api/children/childrenRouter.js
+++ b/api/children/childrenRouter.js
@@ -20,7 +20,7 @@ router.get('/', authRequired, function (req, res) {
     });
 });
 //dont forget authRequired
-router.get('/:id', checkChildExist, authRequired, function (req, res, next) {
+router.get('/:id', authRequired, checkChildExist, function (req, res, next) {
   try {
     res.status(200).json(req.child);
   } catch (error) {
@@ -28,7 +28,7 @@ router.get('/:id', checkChildExist, authRequired, function (req, res, next) {
   }
 });
 //dont forget authRequired
-router.get('/:id/enrollments', checkChildExist, authRequired, async function (
+router.get('/:id/enrollments', authRequired, checkChildExist, async function (
   req,
   res,
   next
@@ -44,9 +44,9 @@ router.get('/:id/enrollments', checkChildExist, authRequired, async function (
 //dont forget authRequired
 router.post(
   '/:id/enrollments',
+  authRequired,
   checkChildExist,
   isChildAlreadyEnrolled,
-  authRequired,
   async (req, res) => {
     // the req.body is only class_id  === > {class_id} , it will get modified in isChildAlreadyEnrolled middleware
     const enroll = await Children.addEnrolledCourse(req.wantToEnroll);

--- a/api/classInstances/classInstancesRouter.js
+++ b/api/classInstances/classInstancesRouter.js
@@ -19,7 +19,7 @@ router.get('/', authRequired, function (req, res) {
     });
 });
 
-router.get('/:class_id', checkClassInstanceExist, authRequired, function (
+router.get('/:class_id', authRequired, checkClassInstanceExist, function (
   req,
   res
 ) {
@@ -33,7 +33,7 @@ router.get('/:class_id', checkClassInstanceExist, authRequired, function (
     });
 });
 
-router.post('/', checkClassInstanceObject, async (req, res) => {
+router.post('/', authRequired, checkClassInstanceObject, async (req, res) => {
   const classInstance = req.body;
   try {
     await Classes.addClassInstance(classInstance).then((inserted) => {
@@ -49,8 +49,8 @@ router.post('/', checkClassInstanceObject, async (req, res) => {
 
 router.put(
   '/:class_id',
-  checkClassInstanceExist,
   authRequired,
+  checkClassInstanceExist,
   (req, res, next) => {
     const class_id = req.params.class_id;
     const newClassObject = req.body;
@@ -68,17 +68,22 @@ router.put(
   }
 );
 
-router.delete('/:class_id', checkClassInstanceExist, (req, res, next) => {
-  const class_id = req.params.class_id;
-  try {
-    Classes.removeClassInstance(class_id).then(() => {
-      res.status(200).json({
-        message: `Schedule with id:'${class_id}' was deleted.`,
+router.delete(
+  '/:class_id',
+  authRequired,
+  checkClassInstanceExist,
+  (req, res, next) => {
+    const class_id = req.params.class_id;
+    try {
+      Classes.removeClassInstance(class_id).then(() => {
+        res.status(200).json({
+          message: `Schedule with id:'${class_id}' was deleted.`,
+        });
       });
-    });
-  } catch (err) {
-    next(err);
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
 
 module.exports = router;

--- a/api/instructor/instructorRouter.js
+++ b/api/instructor/instructorRouter.js
@@ -102,7 +102,7 @@ router.put('/', authRequired, (req, res) => {
   }
 });
 
-router.delete('/:instructor_id', (req, res) => {
+router.delete('/:instructor_id', authRequired, (req, res) => {
   const instructor_id = req.params.instructor_id;
   try {
     Instructors.findByInstructorId(instructor_id).then((instructor) => {

--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -275,7 +275,7 @@ router.put('/', authRequired, (req, res) => {
  *                profile:
  *                  $ref: '#/components/schemas/Profile'
  */
-router.delete('/:okta', (req, res) => {
+router.delete('/:okta', authRequired, (req, res) => {
   const okta = req.params.okta;
   console.log(okta);
   try {


### PR DESCRIPTION
This is a bug fix where there were a bunch of endpoints that didn't require authentication that should've been requiring authentication, and there were some cases in which the db was interacted with before authentication had occurred. I fixed all the instances of these bugs that I could find by moving authRequired before db-interacting middleware and by added authRequired to where it was needed.

https://youtu.be/5eGYhRvXjas
https://trello.com/c/REkRarlg/137-security-bug-make-sure-that-authrequired-is-being-used-before-checking-to-see-that-an-id-is-in-the-database-in-all-instances