### PR TITLE
improper instances of returning 404 mostly corrected

### DIFF
--- a/api/admin/adminMiddleware.js
+++ b/api/admin/adminMiddleware.js
@@ -14,17 +14,17 @@ const checkAdminExist = async (req, res, next) => {
 const checkPayload = (req, res, next) => {
   const { email, name, okta_id, role } = req.body;
   if (role === '' || role === undefined) {
-    next({ status: 404, message: 'role is required' });
+    next({ status: 400, message: 'role is required' });
   }
   if (email === '' || email === undefined) {
-    next({ status: 404, message: 'email is required' });
+    next({ status: 400, message: 'email is required' });
   }
   if (name === '' || name === undefined) {
-    next({ status: 404, message: 'name is required' });
+    next({ status: 400, message: 'name is required' });
   }
 
   if (okta_id === '' || okta_id === undefined) {
-    next({ status: 404, message: 'okta_id is required' });
+    next({ status: 400, message: 'okta_id is required' });
   } else {
     next();
   }

--- a/api/children/childrenMiddleware.js
+++ b/api/children/childrenMiddleware.js
@@ -14,13 +14,13 @@ const isChildAlreadyEnrolled = async (req, res, next) => {
   const id = req.params.id;
   const { class_id } = req.body;
   const enrolledClasses = await Children.getEnrolledCourses(id);
-  const chidIsenrolled = enrolledClasses.find((item) => {
+  const childIsEnrolled = enrolledClasses.find((item) => {
     if (class_id == item.class_id) {
       return true;
     }
   });
-  if (chidIsenrolled) {
-    next({ status: 404, message: 'child is already enrolled' });
+  if (childIsEnrolled) {
+    next({ status: 400, message: 'child is already enrolled' });
   } else {
     req.wantToEnroll = { child_id: id, ...req.body, class_id: class_id };
 

--- a/api/classInstances/classInstanceMiddleware.js
+++ b/api/classInstances/classInstanceMiddleware.js
@@ -42,7 +42,7 @@ const checkClassInstanceObject = async (req, res, next) => {
     !location
   ) {
     next({
-      status: 404,
+      status: 400,
       message: `Please be sure that all information is submitted in order to add a new class instance to the database. Remember, we need size, open seats remaining, instructor id, course type id, start and end time, start and end date, and the location.`,
     });
   } else {

--- a/api/courseTypes/courseTypesMiddleware.js
+++ b/api/courseTypes/courseTypesMiddleware.js
@@ -5,7 +5,7 @@ const checkIfCourseIsUnique = async (req, res, next) => {
   const course = await Courses.findBySubject(subject);
   if (course) {
     next({
-      status: 404,
+      status: 400,
       message: `Course with a name of ( ${subject} ) already exists.`,
     });
   } else {
@@ -18,7 +18,7 @@ const checkCoursePyload = (req, res, next) => {
     next();
   } else {
     next({
-      status: 404,
+      status: 400,
       message: 'please complete description and subject section.',
     });
   }

--- a/api/middleware/roleAuthentication.js
+++ b/api/middleware/roleAuthentication.js
@@ -5,7 +5,7 @@ const roleAuthentication = (...args) => (req, res, next) => {
   if ([...args].includes(role)) {
     next();
   } else {
-    res.status(404).json({ error: 'No Access' });
+    res.status(401).json({ error: 'No Access' });
   }
 };
 

--- a/api/parent/parentRouter.js
+++ b/api/parent/parentRouter.js
@@ -80,7 +80,7 @@ router.post('/', async (req, res) => {
       res.status(500).json({ message: e.message });
     }
   } else {
-    res.status(404).json({ message: 'Parent details missing.' });
+    res.status(400).json({ message: 'Parent details missing.' });
   }
 });
 


### PR DESCRIPTION
## Description

There were many instances in which 404 was being returned when that was not the appropriate error, so I corrected the instances I found.

Fixes # (issue)

https://trello.com/c/uCloSwHX/141-the-be-should-never-return-a-404-when-the-method-and-path-are-fine

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes

## Details:

https://youtu.be/4Y_Gtk5J1ps

adminMiddleware gives 400 instead of 404 when the issue is empty fields
childrenMiddleware gives 400 instead of 404 when the issue is that a child is already enrolled in a class
chidIsenrolled renamed to childIsEnrolled
classInstanceMiddleware gives 400 instead of 404 when the issue is a missing field
courseTypesMiddleware gives 400 instead of 404 when the issue is that a course's subject is not unique
courseTypesMiddleware gives 400 instead of 404 when the issue is that description or subject are not filled in
roleAuthentication gives 401 instead of 404 when the issue is that the profile doesn't contain one of the allowed roles
parentRouter gives 400 instead of 404 when the issue is the lack of a request body