### PR TITLE
fix incorrect Doc for newsfeed output on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ Updated table Source: https://dbdesigner.page.link/WTZRbVeTR7EzLvs86
 ````
 {
   id: INCREMENT,
-  title: INTEGER,
-  link: INTEGER,
+  title: STRING,
+  link: STRING,
   description: STRING,
   posted_at: TIMESTAMP,
 }


### PR DESCRIPTION
## Description

Fixed a small issue on the README for the newsfeed section, the part that shows the types of the variables in response.
Before it said the Title and the Link were INTEGERS and not STRINGS.

## Loom Video

https://www.loom.com/share/2092ea2481664c15bf57f4b52ab137cb

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
