### PR TITLE
fixed bug on get by class id

### DIFF
--- a/api/classInstances/classInstancesRouter.js
+++ b/api/classInstances/classInstancesRouter.js
@@ -27,7 +27,7 @@ router.get('/:class_id', authRequired, checkClassInstanceExist, function (
   req,
   res
 ) {
-  const class_id = String(req.params.class_id);
+  const class_id = parseInt(req.params.class_id);
   Classes.findByClassInstanceId(class_id)
     .then((class_instance) => {
       res.status(200).json(class_instance);


### PR DESCRIPTION
## Description
Previous code had String(method)  ,was causing error .Replaced with parseInt() and can now successfully get class id.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Loom Video
https://www.loom.com/share/15f5b627d79545828b5a063dc4b4e3b4




Please paste a link here of a quick loom video walking through what you did in your PR .

## Type of change

Please delete options that are not relevant.

-  [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have removed unnecessary comments/console logs from my code
- [ x] I have made corresponding changes to the documentation if necessary (optional)
- [ x] My changes generate no new warnings
- [ x] I have checked my code and corrected any misspellings
- [ x] No duplicate code left within changed files
- [x ] Size of pull request kept to a minimum
- [ x] Pull request description clearly describes changes made & motivations for said changes
