### PR TITLE
updates profile seed file to match Okta user data, adds "update" script

### DIFF
--- a/data/migrations/20200625220949_create_profile.js
+++ b/data/migrations/20200625220949_create_profile.js
@@ -23,5 +23,7 @@ exports.up = (knex) => {
 };
 
 exports.down = (knex) => {
-  return knex.schema.dropTableIfExists('profiles').dropTableIfExists('roles');
+  return knex.schema
+    .raw('DROP TABLE profiles CASCADE')
+    .raw('DROP TABLE roles CASCADE');
 };

--- a/data/seeds/001_profiles.js
+++ b/data/seeds/001_profiles.js
@@ -1,74 +1,74 @@
-// const faker = require('faker');
+const faker = require('faker');
 
-// const profiles = [...new Array(20)].map((i, idx) => ({
-//   okta: idx === 0 ? '00ulthapbErVUwVJy4x6' : faker.random.alphaNumeric(20),
-//   avatarUrl: faker.image.avatar(),
-//   email: idx === 0 ? 'llama001@maildrop.cc"' : faker.internet.email(),
-//   name:
-//     idx === 0
-//       ? 'Test001 User'
-//       : `${faker.name.firstName()} ${faker.name.lastName()}`,
-//   type: Math.floor(Math.random() * 4 + 1),
-// }));
+let profiles = [...new Array(20)].map((i, idx) => ({
+  okta_id: idx === 0 ? '00ulthapbErVUwVJy4x6' : faker.random.alphaNumeric(20),
+  avatarUrl: faker.image.avatar(),
+  email: idx === 0 ? 'llama001@maildrop.cc"' : faker.internet.email(),
+  name:
+    idx === 0
+      ? 'Test001 User'
+      : `${faker.name.firstName()} ${faker.name.lastName()}`,
+  type: Math.floor(Math.random() * 4 + 1),
+}));
 
 /*
   Manually setting the `id` for each profile to the Okta provided ID. Adding
   profiles was not in scope for this iteration, but adding profiles in the 
   future will require the okta-id to be set as the `id` for each profile.
 */
-const profiles = [
+profiles = [
   {
     profile_id: 1,
-    email: 'Test001@maildrop.cc',
+    email: 'llama001@maildrop.cc',
     name: 'Test001 User',
     okta_id: '00ulthapbErVUwVJy4x6',
     role_id: 1,
   },
   {
     profile_id: 2,
-    email: 'Test002@maildrop.cc',
+    email: 'llama002@maildrop.cc',
     name: 'Test002 User',
     okta_id: '00ultwew80Onb2vOT4x6',
     role_id: 2,
   },
   {
     profile_id: 3,
-    email: 'Test003@maildrop.cc',
+    email: 'llama003@maildrop.cc',
     name: 'Test003 User',
     okta_id: '00ultx74kMUmEW8054x6',
     role_id: 3,
   },
   {
     profile_id: 4,
-    email: 'Test004@maildrop.cc',
+    email: 'llama004@maildrop.cc',
     name: 'Test004 User',
     okta_id: '00ultwqjtqt4VCcS24x6',
     role_id: 4,
   },
   {
     profile_id: 5,
-    email: 'Test005@maildrop.cc',
+    email: 'llama005@maildrop.cc',
     name: 'Test005 User',
     okta_id: '00ultwz1n9ORpNFc04x6',
     role_id: 5,
   },
   {
     profile_id: 6,
-    email: 'Test006@maildrop.cc',
+    email: 'llama006@maildrop.cc',
     name: 'Test006 User',
     okta_id: '00u13omswyZM1xVya4x7',
     role_id: 1,
   },
   {
     profile_id: 7,
-    email: 'Test007@maildrop.cc',
+    email: 'llama007@maildrop.cc',
     name: 'Test007 User',
     okta_id: '00u13ol5x1kmKxVJU4x7',
     role_id: 2,
   },
   {
     profile_id: 8,
-    email: 'Test008@maildrop.cc',
+    email: 'llama008@maildrop.cc',
     name: 'Test008 User',
     okta_id: '00u13oned0U8XP8Mb4x7',
     role_id: 3,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "migrateh": "heroku run knex migrate:latest -a coder-heroes-api --knexfile config/knexfile.js",
     "rollbackh": "heroku run knex migrate:rollback -a coder-heroes-api --knexfile config/knexfile.js",
     "databaseh": "heroku pg:psql -a coder-heroes-api --knexfile config/knexfile.js",
-    "deploy": "git push heroku main"
+    "deploy": "git push heroku main",
+    "update": "npx knex --knexfile config/knexfile.js migrate:rollback && npx knex --knexfile config/knexfile.js migrate:latest && npx knex --knexfile config/knexfile.js seed:run"
   },
   "lint-staged": {
     "api/**/*.js": [


### PR DESCRIPTION
## Description

This pull request updates our Profiles table's seed file, reintroducing the initial array-creating formula on line 1 and adjusting the email addresses to match what we have in Okta for these users. This should patch the relationship between FE and BE and allow us to adjust our code for user roles appropriately.

### Additional changes made:

- Added a new script, `update`, as a quality-of-life improvement. Very simply, this script will run our database's rollback, migrate, and seed commands in sequence with only one input rather than 3 separate scripts.

## Loom Video

👀 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
