### PR TITLE
fix: GET /user was not sending back any data

### DIFF
--- a/api/user/userModel.js
+++ b/api/user/userModel.js
@@ -11,8 +11,8 @@ const _findUserData = async (role_id, profile_id) => {
       .where('super_admins.profile_id', profile_id);
   } else if (role_id === 2) {
     return db('profiles')
-      .leftJoin('parents', 'profiles.profile_id', 'parents.profile_id')
-      .where('parents.profile_id', profile_id);
+      .leftJoin('admins', 'profiles.profile_id', 'admins.profile_id')
+      .where('admins.profile_id', profile_id);
   } else if (role_id === 3) {
     return db('profiles')
       .leftJoin('instructors', 'profiles.profile_id', 'instructors.profile_id')

--- a/api/user/userModel.js
+++ b/api/user/userModel.js
@@ -1,6 +1,6 @@
 const db = require('../../data/db-config');
 
-const findUserData = async (role_id, profile_id) => {
+const _findUserData = async (role_id, profile_id) => {
   if (role_id === 1) {
     return db('profiles')
       .leftJoin(
@@ -28,6 +28,13 @@ const findUserData = async (role_id, profile_id) => {
   }
 };
 
+const findUserData = async (role_id, profile_id) => {
+  return _findUserData(role_id, profile_id).then((users) => {
+    //FindUser should return only one user , so we make sure that
+    // a single user is returned instead of an array of 1 user
+    return Array.isArray(users) ? users[0] : users;
+  });
+};
 const getInbox = (okta) => {
   return db('profiles')
     .leftJoin('inboxes', 'profiles.profile_id', 'inboxes.profile_id')

--- a/api/user/userRouter.js
+++ b/api/user/userRouter.js
@@ -5,8 +5,8 @@ const User = require('./userModel');
 const router = express.Router();
 
 router.get('/', authRequired, function (req, res) {
-  const { role, profile_id } = req.profile;
-  User.findUserData(role, profile_id)
+  const { role_id, profile_id } = req.profile;
+  User.findUserData(role_id, profile_id)
     .then((user) => {
       res.status(200).json(user);
     })


### PR DESCRIPTION
## Description

Fixed: GET /user endpoint was not sending back any data.
After finding the bug and creating a helper function _findUserData, now the /user endpoint sends back an object of the user's profile.

Collaborator: George Cavazos helped on fixing this issue

Fixes # (issue)
n/a

## Loom Video
https://www.loom.com/share/4d2a5b76d84243fdaacb4af89ea3c034


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
