### PR TITLE
Fix: GET /profile/role/:role_id was not sending back data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,26 @@
 }
 ```
 
-| Method   | URL                         | Description                                                                                                              |
-| -------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [GET]    | /profile/                   | Returns an array of all existing profiles.                                                                              |
-| [GET]    | /profile/:okta_id/       | Returns the profile object with the specified `okta_id`.                                                                       |
+| Method   | URL                                                                                                                    | Description                                                                                                              |
+| -------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [GET]    | /profile/                                                                                                              | Returns an array of all existing profiles.                                                                               |
+| [GET]    | /profile/:okta_id/                                                                                                     | Returns the profile object with the specified `okta_id`.                                                                 |
 | [GET]    | /profiles/users/:profile_id <b>(BUG: /profiles/users route does not exist; app.js only connects to /profiles/user)</b> | Returns an array filled with event objects that contains information based on profile_id and role_id.                    |
-| [GET]    | /profile/role/:role_id <b>(BUG: does not return any data)</b>      | Returns an array filled with event objects that contain information based on role_id for all profiles of a role_id type. |
-| [POST]   | /profile/                   | Requires a name, password, and email. Registers a new user.                                                              |
-| [PUT]    | /profile/                   | Returns an event object with the specified `okta`. Updates specific profile.                                             |
-| [DELETE] | /profile/:okta_id/             | Returns an event object with the specified `okta`. Deletes specific profile.                                             |
+| [GET]    | /profile/role/:role_id                                                                                                 | Returns an array filled with event objects that contain information based on role_id for all profiles of a role_id type. |
+| [POST]   | /profile/                                                                                                              | Requires a name, password, and email. Registers a new user.                                                              |
+| [PUT]    | /profile/                                                                                                              | Returns an event object with the specified `okta`. Updates specific profile.                                             |
+| [DELETE] | /profile/:okta_id/                                                                                                     | Returns an event object with the specified `okta`. Deletes specific profile.                                             |
+
 #### User:
+
 <p>These endpoints are user-focused. As opposed to the more flexible Profile endpoints where <b>profile_id</b> must be specified, these endpoints retrieve data specific only to the user profile that is making the API request by using the logged-in user's <b>profile_id</b>.</p>
 
-| Method | URL              | Description                                                             |
-| ------ | ---------------- | ----------------------------------------------------------------------- |
-| [GET]  | /user/           | Returns an event object with the specified `okta` and `type`.           |
-| [GET]  | /user/inbox/     | Returns an event object with the specified `okta`. <b>(NOT IMPLEMENTED)</b>    |
-| [GET]  | /user/schedules/ | Returns an event object with the specified `okta`.                      |
-| [PUT]  | /user/           | Returns an event object with the specified `id`. Updates specific user. |
+| Method | URL              | Description                                                                 |
+| ------ | ---------------- | --------------------------------------------------------------------------- |
+| [GET]  | /user/           | Returns an event object with the specified `okta` and `type`.               |
+| [GET]  | /user/inbox/     | Returns an event object with the specified `okta`. <b>(NOT IMPLEMENTED)</b> |
+| [GET]  | /user/schedules/ | Returns an event object with the specified `okta`.                          |
+| [PUT]  | /user/           | Returns an event object with the specified `id`. Updates specific user.     |
 
 <h1>Parents</h1>
 
@@ -41,9 +43,9 @@
 }
 ```
 
-| Method | URL                    | Description                                                         |
-| ------ | ---------------------- | ------------------------------------------------------------------- |
-| [GET]  | /parent/:profile_id/children/  | Returns an array filled with children event objects with the specified `profile_id`. |
+| Method | URL                            | Description                                                                           |
+| ------ | ------------------------------ | ------------------------------------------------------------------------------------- |
+| [GET]  | /parent/:profile_id/children/  | Returns an array filled with children event objects with the specified `profile_id`.  |
 | [GET]  | /parent/:profile_id/schedules/ | Returns an array filled with schedules event objects with the specified `profile_id`. |
 
 <h1>Children</h1>
@@ -58,15 +60,14 @@
 }
 ```
 
-| Method   | URL                       | Description                                                                        |
-| -------- | ------------------------- | ---------------------------------------------------------------------------------- |
-| [GET]    | /children                  | Returns an array containing all existing children.   
-| [GET]    | /children/:id | Returns the child with the given 'id'.   
-| [GET]    | /children/:id/enrollments | Returns an array filled with event objects with the specified `id`.                |
-| [POST]   | /children/:id/enrollments | Returns the event object with the specified `id`. Enrolls a student.               |
-| [PUT]    | /children/enrollments/    | Returns the event object with the specified `id`. Updates a student's enrollments. <b>(Not Implemented)</b>|
-| [DELETE] | /children/enrollments/:id | Returns the event object with the specified `id`. Unenrolls student from course. <b>(Not Implemented)</b>|
-
+| Method   | URL                       | Description                                                                                                 |
+| -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [GET]    | /children                 | Returns an array containing all existing children.                                                          |
+| [GET]    | /children/:id             | Returns the child with the given 'id'.                                                                      |
+| [GET]    | /children/:id/enrollments | Returns an array filled with event objects with the specified `id`.                                         |
+| [POST]   | /children/:id/enrollments | Returns the event object with the specified `id`. Enrolls a student.                                        |
+| [PUT]    | /children/enrollments/    | Returns the event object with the specified `id`. Updates a student's enrollments. <b>(Not Implemented)</b> |
+| [DELETE] | /children/enrollments/:id | Returns the event object with the specified `id`. Unenrolls student from course. <b>(Not Implemented)</b>   |
 
 <h1>Instructors</h1>
 
@@ -82,8 +83,8 @@
 }
 ```
 
-| Method | URL                      | Description                                                         |
-| ------ | ------------------------ | ------------------------------------------------------------------- |
+| Method | URL                  | Description                                                                                           |
+| ------ | -------------------- | ----------------------------------------------------------------------------------------------------- |
 | [GET]  | /instructor/courses/ | Returns an array containing all course event objects belonging to the currently logged in instructor. |
 
 <h1>Programs</h1>
@@ -126,12 +127,12 @@
 }
 ```
 
-| Method   | URL                       | Description                                                                 |
-| -------- | ------------------------- | --------------------------------------------------------------------------- |
-| [GET]    | /course          | Returns an array containing all course objects                         |
-| [GET]    | /course/:course_id | Returns the course object with the specified `course_id`.                           |
-| [PUT]    | /course/:course_id | Updates and returns the updated course object with the specified `course_id`. |
-| [DELETE] | /course/:course_id | Deletes the course object with the specified `course_id` and returns a message containing the deleted course_id on successful deletion   |
+| Method   | URL                | Description                                                                                                                            |
+| -------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [GET]    | /course            | Returns an array containing all course objects                                                                                         |
+| [GET]    | /course/:course_id | Returns the course object with the specified `course_id`.                                                                              |
+| [PUT]    | /course/:course_id | Updates and returns the updated course object with the specified `course_id`.                                                          |
+| [DELETE] | /course/:course_id | Deletes the course object with the specified `course_id` and returns a message containing the deleted course_id on successful deletion |
 
 <h1>Newsfeed</h1>
 
@@ -145,13 +146,13 @@
 }
 ```
 
-| Method   | URL            | Description                                                                |
-| -------- | -------------- | -------------------------------------------------------------------------- |
-| [GET]    | /newsfeed/     | Returns an array containing all newsfeed objects.                                |
-| [GET]    | /newsfeed/:newsfeed_id/ | Returns the event object with the specified `newsfeed_id`.                          |
-| [POST]   | /newsfeed/     | Creates a new newsfeed object and returns the newly created newsfeed.     |
-| [PUT]    | /newsfeed/:newsfeed_id     | Updates the newsfeed object with the given newsfeed_id and returns the newly updated newsfeed |
-| [DELETE] | /newsfeed/:newsfeed_id/ | Deletes the newsfeed object with the given newsfeed_id and returns the deleted newsfeed. |
+| Method   | URL                     | Description                                                                                   |
+| -------- | ----------------------- | --------------------------------------------------------------------------------------------- |
+| [GET]    | /newsfeed/              | Returns an array containing all newsfeed objects.                                             |
+| [GET]    | /newsfeed/:newsfeed_id/ | Returns the event object with the specified `newsfeed_id`.                                    |
+| [POST]   | /newsfeed/              | Creates a new newsfeed object and returns the newly created newsfeed.                         |
+| [PUT]    | /newsfeed/:newsfeed_id  | Updates the newsfeed object with the given newsfeed_id and returns the newly updated newsfeed |
+| [DELETE] | /newsfeed/:newsfeed_id/ | Deletes the newsfeed object with the given newsfeed_id and returns the deleted newsfeed.      |
 
 <h1>Inboxes</h1>
 
@@ -162,14 +163,14 @@
 }
 ```
 
-| Method   | URL              | Description                                                                              |
-| -------- | ---------------- | ---------------------------------------------------------------------------------------- |
-| [GET]    | /inbox/          | Returns an array filled with inbox event objects.                                              |
-| [GET]    | /inbox/:profile_id/    | Retrieves an inbox with the specified inbox_id <b>BUG(?): incorrectly labeled as profile_id in codebase rather than inbox_id</b> |
-| [POST]   | /inbox/          | Creates an inbox and returns the newly created inbox.                 |
-| [POST]   | /inbox/messages/ | Returns the event object with the specified `inbox_id`. Sends a message.                 |
-| [PUT]    | /inbox/:profile_id   | Returns an array filled with event objects with the specific `profile_id`. Updates an inbox.   |
-| [DELETE] | /inbox/:profile_id/    | Returns an array filled with event objects with the specific `okta`. Deletes an inbox.   |
+| Method   | URL                 | Description                                                                                                                      |
+| -------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| [GET]    | /inbox/             | Returns an array filled with inbox event objects.                                                                                |
+| [GET]    | /inbox/:profile_id/ | Retrieves an inbox with the specified inbox_id <b>BUG(?): incorrectly labeled as profile_id in codebase rather than inbox_id</b> |
+| [POST]   | /inbox/             | Creates an inbox and returns the newly created inbox.                                                                            |
+| [POST]   | /inbox/messages/    | Returns the event object with the specified `inbox_id`. Sends a message.                                                         |
+| [PUT]    | /inbox/:profile_id  | Returns an array filled with event objects with the specific `profile_id`. Updates an inbox.                                     |
+| [DELETE] | /inbox/:profile_id/ | Returns an array filled with event objects with the specific `okta`. Deletes an inbox.                                           |
 
 <h1>Calendar Events</h1>
 
@@ -185,15 +186,14 @@
 }
 ```
 
-
-| Method   | URL              | Description                                                                              |
-| -------- | ---------------- | ---------------------------------------------------------------------------------------- |
-| [GET]    | /calendar-events/          | Returns an array filled with calendar event objects.                                              |
-| [GET]    | /calendar-events/user/    | Retrieves calendar event objects with the profile_id of logged in user |
-| [GET]    | /calendar-events/:event_id/    | Retrieves calendar event object with the specified event_id |
-| [POST]   | /calendar-events/          | Creates a calendar event and returns the newly created calendar event.                 |
-| [PUT]    | /calendar-events/:event_id   | Updates and returns the updated calendar event object with the specific `event_id`.   |
-| [DELETE] | /calendar-events/:event_id/    | Deletes a calendar event and returns a success message on successful deletion.    |
+| Method   | URL                         | Description                                                                         |
+| -------- | --------------------------- | ----------------------------------------------------------------------------------- |
+| [GET]    | /calendar-events/           | Returns an array filled with calendar event objects.                                |
+| [GET]    | /calendar-events/user/      | Retrieves calendar event objects with the profile_id of logged in user              |
+| [GET]    | /calendar-events/:event_id/ | Retrieves calendar event object with the specified event_id                         |
+| [POST]   | /calendar-events/           | Creates a calendar event and returns the newly created calendar event.              |
+| [PUT]    | /calendar-events/:event_id  | Updates and returns the updated calendar event object with the specific `event_id`. |
+| [DELETE] | /calendar-events/:event_id/ | Deletes a calendar event and returns a success message on successful deletion.      |
 
 <h1>Schedule (Not Implemented)</h1>
 
@@ -205,7 +205,6 @@
 | [POST]   | /schedule/sessions/ | Returns the event object with the specified `id`. Creates a session.         |
 | [PUT]    | /schedule/          | Returns the event object with the specified `id`. Updates specific schedule. |
 | [DELETE] | /schedule/:id/      | Returns the event object with the specified `id`. Deletes specific schedule. |
-
 
 <h1>Data Tables Without Existing Endpoints</h1>
 
@@ -276,7 +275,7 @@
 }
 ```
 
-Visual Database Schema: https://dbdesigner.page.link/WTZRbVeTR7EzLvs86 <b>*Currently Outdated</b>
+Visual Database Schema: https://dbdesigner.page.link/WTZRbVeTR7EzLvs86 <b>\*Currently Outdated</b>
 
 [Loom Video PT1](https://www.loom.com/share/4543abe4659540698c327058362f90f3)
 [Loom Video PT2](https://www.loom.com/share/c4e8c8f38cb14fdb8ac43e6a2342f159)

--- a/api/courses/coursesRouter.js
+++ b/api/courses/coursesRouter.js
@@ -226,7 +226,13 @@ router.get('/', authRequired, function (req, res, next) {
  */
 
 router.get('/:course_id', authRequired, checkCourseExists, function (req, res) {
-  res.status(200).json(req.courses);
+  Courses.findByCourseId(req.params.course_id)
+    .then((course) => {
+      res.status(200).json(course);
+    })
+    .catch(() => {
+      res.status(500).json(`Course was not found`);
+    });
 });
 
 /**

--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -10,7 +10,7 @@ const {
 } = require('./profileMiddleware');
 
 router.get('/role/:role_id', authRequired, checkRoleExist, function (req, res) {
-  const role_id = req.params.role_id;
+  const role_id = req.profile.role_id;
   Profiles.findByRoleId(role_id)
     .then((roleList) => {
       res.status(200).json(roleList);

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,8 @@
         "lint-staged": "^10.4.2",
         "nodemon": "^2.0.4",
         "prettier": "^2.0.5",
-        "supertest": "^4.0.2"
+        "supertest": "^4.0.2",
+        "supervisor": "^0.12.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -9906,6 +9907,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/supervisor": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/supervisor/-/supervisor-0.12.0.tgz",
+      "integrity": "sha1-3n5jNwFbKRhRwQ81OMSn8EkX7ME=",
+      "dev": true,
+      "bin": {
+        "node-supervisor": "lib/cli-wrapper.js",
+        "supervisor": "lib/cli-wrapper.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -18636,6 +18650,12 @@
         "methods": "^1.1.2",
         "superagent": "^3.8.3"
       }
+    },
+    "supervisor": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/supervisor/-/supervisor-0.12.0.tgz",
+      "integrity": "sha1-3n5jNwFbKRhRwQ81OMSn8EkX7ME=",
+      "dev": true
     },
     "supports-color": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "migrate": "knex migrate:latest --knexfile config/knexfile.js",
     "rollback": "knex migrate:rollback --knexfile config/knexfile.js",
     "watch:dev": "nodemon",
+    "server": "supervisor server.js",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint --fix .",
     "format": "npx prettier --write \"**/*.+(js|jsx|json|yml|yaml|css|md)\"",
@@ -97,6 +98,7 @@
     "lint-staged": "^10.4.2",
     "nodemon": "^2.0.4",
     "prettier": "^2.0.5",
-    "supertest": "^4.0.2"
+    "supertest": "^4.0.2",
+    "supervisor": "^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "migrate": "knex migrate:latest --knexfile config/knexfile.js",
     "rollback": "knex migrate:rollback --knexfile config/knexfile.js",
     "watch:dev": "nodemon",
-    "server": "supervisor server.js",
+    "watch:dev:windows": "supervisor server.js",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint --fix .",
     "format": "npx prettier --write \"**/*.+(js|jsx|json|yml|yaml|css|md)\"",


### PR DESCRIPTION
## Description

GET /profile/role/:role_id route was not sending back data. The bug was on line 13 and after changing `req.params.role_id` to `req.profile.role_id` we were able to successfully return profiles with specific role_id's.  

Collaborators: [Berenika Ahmetaj](https://github.com/Berenika14), [Anthony Amaya](https://github.com/aamay022)

Fixes # (issue)

Updated line 13 in profileRouter from `req.params.role_id` to `req.profile.role_id` 

## Loom Video

https://www.loom.com/share/48a4515bc3834b9c86ae5d3b54004bd2

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
