### PR TITLE
Fix: GET /course/course_id was not sending back specific course

### DIFF
--- a/api/courses/coursesRouter.js
+++ b/api/courses/coursesRouter.js
@@ -225,8 +225,19 @@ router.get('/', authRequired, function (req, res, next) {
  *       description: 'Course Instance with id {course_id} does not exist'
  */
 
-router.get('/:course_id', authRequired, checkCourseExists, function (req, res) {
-  res.status(200).json(req.courses);
+router.get('/:course_id', authRequired, checkCourseExists, function (
+  req,
+  res,
+  next
+) {
+  const { course_id } = req.course;
+  try {
+    Courses.findByCourseId(course_id).then((course) => {
+      res.status(200).json(course);
+    });
+  } catch (err) {
+    next(err);
+  }
 });
 
 /**


### PR DESCRIPTION
## Description

We addressed a problem with the GET /course/course_id endpoint not sending back any data, and after reviewing the endpoint, we built out the request for the endpoint and now we are successfully receiving back data.

In addition, our front end is now able to successfully update courses.

Collaborators: [George Cavazos](https://github.com/cavazosgeorge), [Berenika Ahmetaj](https://github.com/Berenika14)

Fixes # (issue)

## Loom Video

https://www.loom.com/share/d11cd70ca0c5408084d161777d755a01

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes