### PR TITLE
BL-309 changed API_TOKEN inside the env sample file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,4 +6,4 @@ TESTING_DATABASE_URL=postgres://docker:docker@127.0.0.1:5400/api-dev-testing
 OKTA_URL_ISSUER=https://example.okta.com/oauth2/default
 OKTA_CLIENT_ID=example
 ORG_URL=https://example.okta.com
-API_TOKEN=SUPERSECRET
+OKTA_API_TOKEN=SUPERSECRET

--- a/lib/oktaClient.js
+++ b/lib/oktaClient.js
@@ -2,7 +2,7 @@ const okta = require('@okta/okta-sdk-nodejs');
 
 const client = new okta.Client({
   orgUrl: `${process.env.ORG_URL}`,
-  token: `${process.env.API_TOKEN}`,
+  token: `${process.env.OKTA_API_TOKEN}`,
 });
 
 module.exports = client;


### PR DESCRIPTION
## Description

The notion documentation, shows a different field for the okta api token than the one that is currently in place. This might get a bit confusing for some developers, so I simply replaced API_TOKEN from the .env sample file and also the usage of it in oktaClient file inside the lib folder with OKTA_API_TOKEN. The register route still works perfectly fine. 

Fixes # (issue)

## Loom Video
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
