### PR TITLE
BL-783-be-i-want-to-add-a-child-profile

### DIFF
--- a/api/parent/parentRouter.js
+++ b/api/parent/parentRouter.js
@@ -37,7 +37,6 @@ router.put(
     try {
       let [child] = await Children.updateChild(child_id, req.body);
       res.status(200).json(child);
-      console.log(res);
     } catch (error) {
       next(error);
     }
@@ -54,6 +53,19 @@ router.delete(
     try {
       let { name } = await Children.removeChild(child_id);
       res.status(200).json({ name });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+router.get(
+  '/:child_id',
+  authRequired,
+  checkChildExist,
+  async function (req, res, next) {
+    try {
+      res.status(200).json(req.child);
     } catch (error) {
       next(error);
     }

--- a/api/parent/parentRouter.js
+++ b/api/parent/parentRouter.js
@@ -1,18 +1,47 @@
 const express = require('express');
 const authRequired = require('../middleware/authRequired');
+const {
+  roleAuthenticationParent,
+} = require('../middleware/roleAuthentication.js');
+const {
+  checkChildObject,
+  checkChildExist,
+} = require('../children/ChildrenMiddleware');
 const Parents = require('./parentModel');
 const Children = require('../children/childrenModel');
 const router = express.Router();
 
-router.post('/', authRequired, async function (req, res, next) {
-  const { profile_id } = req.profile;
-  try {
-    let child = await Children.addChild(profile_id, req.body);
-    res.status(201).json(child);
-  } catch (error) {
-    next(error);
+router.post(
+  '/',
+  authRequired,
+  roleAuthenticationParent,
+  checkChildObject,
+  async function (req, res, next) {
+    const { profile_id } = req.profile;
+    try {
+      let child = await Children.addChild(profile_id, req.body);
+      res.status(201).json(child);
+    } catch (error) {
+      next(error);
+    }
   }
-});
+);
+
+router.put(
+  '/:child id',
+  authRequired,
+  roleAuthenticationParent,
+  checkChildExist,
+  async function (req, res, next) {
+    const { child_id } = req.params;
+    try {
+      let [child] = await Children.updateChild(child_id, req.body);
+      res.status(200).json(child);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
 
 router.get('/:profile_id/children', authRequired, function (req, res) {
   const { profile_id } = req.params;

--- a/api/parent/parentRouter.js
+++ b/api/parent/parentRouter.js
@@ -1,7 +1,18 @@
 const express = require('express');
 const authRequired = require('../middleware/authRequired');
 const Parents = require('./parentModel');
+const Children = require('../children/childrenModel');
 const router = express.Router();
+
+router.post('/', authRequired, async function (req, res, next) {
+  const { profile_id } = req.profile;
+  try {
+    let child = await Children.addChild(profile_id, req.body);
+    res.status(201).json(child);
+  } catch (error) {
+    next(error);
+  }
+});
 
 router.get('/:profile_id/children', authRequired, function (req, res) {
   const { profile_id } = req.params;

--- a/api/parent/parentRouter.js
+++ b/api/parent/parentRouter.js
@@ -19,8 +19,8 @@ router.post(
   async function (req, res, next) {
     const { profile_id } = req.profile;
     try {
-      let child = await Children.addChild(profile_id, req.body);
-      res.status(201).json(child);
+      let newChild = await Children.addChild(profile_id, req.body);
+      res.status(201).json(newChild);
     } catch (error) {
       next(error);
     }
@@ -35,8 +35,8 @@ router.put(
   async function (req, res, next) {
     const { child_id } = req.params;
     try {
-      let [child] = await Children.updateChild(child_id, req.body);
-      res.status(200).json(child);
+      let [updatedChild] = await Children.updateChild(child_id, req.body);
+      res.status(200).json(updatedChild);
     } catch (error) {
       next(error);
     }
@@ -53,19 +53,6 @@ router.delete(
     try {
       let { name } = await Children.removeChild(child_id);
       res.status(200).json({ name });
-    } catch (error) {
-      next(error);
-    }
-  }
-);
-
-router.get(
-  '/:child_id',
-  authRequired,
-  checkChildExist,
-  async function (req, res, next) {
-    try {
-      res.status(200).json(req.child);
     } catch (error) {
       next(error);
     }

--- a/api/parent/parentRouter.js
+++ b/api/parent/parentRouter.js
@@ -28,7 +28,7 @@ router.post(
 );
 
 router.put(
-  '/:child id',
+  '/:child_id',
   authRequired,
   roleAuthenticationParent,
   checkChildExist,
@@ -37,6 +37,23 @@ router.put(
     try {
       let [child] = await Children.updateChild(child_id, req.body);
       res.status(200).json(child);
+      console.log(res);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+router.delete(
+  '/:child_id',
+  authRequired,
+  roleAuthenticationParent,
+  checkChildExist,
+  async function (req, res, next) {
+    const { child_id } = req.params;
+    try {
+      let { name } = await Children.removeChild(child_id);
+      res.status(200).json({ name });
     } catch (error) {
       next(error);
     }


### PR DESCRIPTION
## Description

Added the ability for a single parent to create a child profile and then gave the parent the ability to update a child based on the given child identification. The parent also now has the ability to delete a child profile, if necessary. The ability for a parent to grab a child based on the profile Id was already created however on review that get request may need to be reassessed as the only profile_id that seems to exist is the profile_id = 1. A single parent can still grab children but it is only under the single profile of 1. 
Fixes # (issue)

https://www.loom.com/share/20cad4888c544766bf6c1b5ac887a1fa

Please paste a link here of a quick loom video walking through what you did in your PR .

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code

- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
